### PR TITLE
fix: Correct multi-method definition syntax error in UI files

### DIFF
--- a/ui_my_tickets_view.py
+++ b/ui_my_tickets_view.py
@@ -174,10 +174,17 @@ if __name__ == '__main__':
     app = QApplication(sys.argv)
     class DummyUserForMyTicketsView(User):
         def __init__(self, u="test_viewer", r="EndUser", uid="viewer_uid_123"):
-            self.username=u; self.role=r; self.user_id=uid # type: ignore
+            self.username = u
+            self.role = r
+            self.user_id = uid # type: ignore
             if not hasattr(self, 'ROLES') or self.ROLES is None:
                  class TR: __args__ = ('EndUser',); User.ROLES=TR; self.ROLES=TR # type: ignore
-        def set_password(self,p):pass; def check_password(self,p):return False
+
+        def set_password(self,p):
+            pass
+
+        def check_password(self,p):
+            return False
     test_user = DummyUserForMyTicketsView()
 
     _og_list_tickets = ticket_manager.list_tickets


### PR DESCRIPTION
I corrected a SyntaxError in `ui_my_tickets_view.py` within its `if __name__ == '__main__':` block. Multiple method definitions (set_password, check_password) for a dummy class were on a single line and I've separated them onto their own lines with proper indentation.

I performed a targeted scan of all ui_*.py files to ensure no other instances of this specific "multiple defs on one line" pattern existed. Previous fixes had already addressed this in `ui_create_ticket_view.py`.

These changes resolve syntax errors that occurred during Python's parsing of the files.