### PR TITLE
Fix: Correct additional SyntaxError in ui_ticket_detail_view.py

### DIFF
--- a/ui_ticket_detail_view.py
+++ b/ui_ticket_detail_view.py
@@ -349,7 +349,6 @@ class TicketDetailView(QWidget):
     def handle_upload_staged_attachments(self): # Unchanged
         if not self.current_ticket_id: QMessageBox.warning(self, "No Ticket", "No ticket loaded."); return
         if not self.staged_files_for_upload: QMessageBox.information(self, "No Files", "No files staged."); return
-        sc=0;for sp,on in list(self.staged_files_for_upload):
         sc=0
         for sp,on in list(self.staged_files_for_upload):
             try:


### PR DESCRIPTION
This commit addresses a SyntaxError on line 352 of `ui_ticket_detail_view.py` within the `handle_upload_staged_attachments` method.

The error was caused by an attempt to initialize a variable and start a for loop on the same line (e.g., `sc=0;for ...`). This line was a duplicated artifact and has been removed. The subsequent lines already contained the correct, separate initialization and loop structure.

This fix follows a previous correction for a similar duplicated code issue in the `_calculate_and_display_sla_status` method in the same file.