### PR TITLE
Fix: Correct PySide6 import errors for QDesktopServices and QShowEvent

### DIFF
--- a/ui_change_password_dialog.py
+++ b/ui_change_password_dialog.py
@@ -1,11 +1,7 @@
 import sys
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
-
-    QPushButton, QDialogButtonBox, QMessageBox, QApplication
-
     QPushButton, QDialogButtonBox, QMessageBox, QApplication, QWidget
-    main
 )
 from PySide6.QtCore import Slot, Qt
 from typing import Optional, TYPE_CHECKING

--- a/ui_dashboard_view.py
+++ b/ui_dashboard_view.py
@@ -226,11 +226,8 @@ if __name__ == '__main__':
                  class TempRoles: __args__ = ('TechManager', 'EndUser')
                  User.ROLES = TempRoles; self.ROLES = TempRoles # type: ignore
 
-        def set_password(self,p):pass; def check_password(self,p):return False
-
         def set_password(self,p):pass
         def check_password(self,p):return False
-
 
     test_user = DummyUserForDashboard()
 

--- a/ui_kb_article_view.py
+++ b/ui_kb_article_view.py
@@ -253,7 +253,6 @@ if __name__ == '__main__':
             if not hasattr(self, 'ROLES') or self.ROLES is None:
                  class TR: __args__ = ('TechManager','EndUser'); User.ROLES=TR; self.ROLES=TR #type: ignore
 
-        def set_password(self,p):pass; def check_password(self,p):return False
         def set_password(self,p):pass
         def check_password(self,p):return False
     test_user = DummyUserKB()

--- a/ui_reporting_view.py
+++ b/ui_reporting_view.py
@@ -245,7 +245,6 @@ if __name__ == '__main__':
             if not hasattr(self, 'ROLES') or self.ROLES is None:
                  class TR: __args__ = ('EngManager','EndUser'); User.ROLES=TR; self.ROLES=TR #type: ignore
 
-        def set_password(self,p):pass; def check_password(self,p):return False
         def set_password(self,p):pass
         def check_password(self,p):return False
     test_user = DummyUserForReporting()

--- a/ui_ticket_detail_view.py
+++ b/ui_ticket_detail_view.py
@@ -9,9 +9,6 @@ from PySide6.QtWidgets import (
     QFileDialog, QListWidget, QListWidgetItem, QToolButton, QSizePolicy,
     QDialog, QDialogButtonBox, QTextBrowser # Added QTextBrowser
 )
-from PySide6.QtCore import Slot, Qt, Signal, QSize, QUrl, QDesktopServices
-from PySide6.QtGui import QFont, QIcon
-
 from PySide6.QtCore import Slot, Qt, Signal, QSize, QUrl
 from PySide6.QtGui import QFont, QIcon, QDesktopServices
 

--- a/ui_user_management_view.py
+++ b/ui_user_management_view.py
@@ -6,8 +6,6 @@ from PySide6.QtWidgets import (
     QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView,
     QGroupBox, QApplication, QMessageBox
 )
-from PySide6.QtCore import Slot, Qt, QShowEvent # Added QShowEvent
-from PySide6.QtGui import QFont
 from PySide6.QtCore import Slot, Qt
 from PySide6.QtGui import QFont, QShowEvent
 
@@ -66,15 +64,6 @@ class UserManagementView(QWidget):
         # --- Edit/Add User Section ---
         details_groupbox = QGroupBox("User Details"); details_main_layout = QVBoxLayout(details_groupbox)
         form_layout = QFormLayout(); self.detail_user_id_label = QLabel("User ID: N/A"); form_layout.addRow(self.detail_user_id_label)
-        form_layout.addRow(QLabel("Username:"), self.detail_username_edit = QLineEdit())
-        self.detail_role_combo = QComboBox();
-        if hasattr(User, 'ROLES') and User.ROLES and hasattr(User.ROLES, '__args__'): self.detail_role_combo.addItems(User.ROLES.__args__) # type: ignore
-        form_layout.addRow(QLabel("Role:"), self.detail_role_combo)
-        checkbox_layout = QHBoxLayout(); self.detail_is_active_check = QCheckBox("Is Active"); checkbox_layout.addWidget(self.detail_is_active_check)
-        self.detail_force_reset_check = QCheckBox("Force Password Reset"); checkbox_layout.addWidget(self.detail_force_reset_check); form_layout.addRow(checkbox_layout)
-        self.password_group_widget = QWidget(); password_qform_layout = QFormLayout(self.password_group_widget); password_qform_layout.setContentsMargins(0,0,0,0)
-        self.detail_new_password_edit = QLineEdit(); self.detail_new_password_edit.setEchoMode(QLineEdit.Password); password_qform_layout.addRow(QLabel("New Password:"), self.detail_new_password_edit
-        self.detail_confirm_password_edit = QLineEdit(); self.detail_confirm_password_edit.setEchoMode(QLineEdit.Password); password_qform_layout.addRow(QLabel("Confirm Password:"), self.detail_confirm_password_edit)
         self.detail_username_edit = QLineEdit()
         form_layout.addRow(QLabel("Username:"), self.detail_username_edit)
         self.detail_role_combo = QComboBox();
@@ -284,7 +273,6 @@ if __name__ == '__main__':
                  class TR: __args__ = ('EndUser', 'Technician', 'Engineer', 'TechManager', 'EngManager')
                  User.ROLES = TR #type: ignore
             self.ROLES = User.ROLES #type: ignore
-        def set_password(self,p):pass; def check_password(self,p):return False
         def set_password(self,p):pass
         def check_password(self,p):return False
 


### PR DESCRIPTION
I've corrected two import errors in your codebase:

1.  `QDesktopServices` was being incorrectly imported from `PySide6.QtCore` in `ui_ticket_detail_view.py`. I've changed this to correctly import it from `PySide6.QtGui`.

2.  `QShowEvent` was being incorrectly imported from `PySide6.QtCore` in `ui_user_management_view.py`. I've changed this to correctly import it from `PySide6.QtGui`.

These changes address the `ImportError` exceptions that were preventing your application from starting correctly.

Note: I couldn't perform full GUI testing due to a Qt platform error (xcb plugin) in the execution environment, which is unrelated to these code changes.