### PR TITLE
feat: Render Markdown in ticket comments and KB popups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6
 Werkzeug
 matplotlib
+markdown2


### PR DESCRIPTION
Implemented Markdown rendering for ticket comments in the TicketDetailView. KB article content viewed via ticket links will now be displayed with its original Markdown formatting.

Changes include:
- Added `markdown2` to `requirements.txt` for Markdown to HTML conversion.
- Modified `ui_ticket_detail_view.py`:
    - Imported `markdown2` library.
    - Updated the `_populate_comments` method to convert comment text from Markdown to HTML using `markdown2`. Includes a fallback to basic HTML escaping if `markdown2` is not found.
    - Added a new method `_process_html_for_kb_links` to handle the conversion of custom `[KB:Name](kb://id)` links to HTML `<a>` tags after the main Markdown conversion.
    - Removed the old `process_text_for_kb_links` method.
- Enhanced the `__main__` block in `ui_ticket_detail_view.py` with more diverse Markdown examples in comments for testing purposes.

This addresses the issue where KB articles or Markdown-formatted text appeared as a "wall of text" in ticket comments.